### PR TITLE
[feat] 요구사항에 따른 Domain model 구현 및 DB 연결 (#1) #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.postgresql:postgresql:42.6.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/gdsc/cau/alert/AlertApplication.java
+++ b/src/main/java/gdsc/cau/alert/AlertApplication.java
@@ -2,7 +2,9 @@ package gdsc.cau.alert;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class AlertApplication {
 

--- a/src/main/java/gdsc/cau/alert/config/JpaAuditingConfig.java
+++ b/src/main/java/gdsc/cau/alert/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package gdsc.cau.alert.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/gdsc/cau/alert/post/domain/Notification.java
+++ b/src/main/java/gdsc/cau/alert/post/domain/Notification.java
@@ -1,0 +1,34 @@
+package gdsc.cau.alert.post.domain;
+
+import gdsc.cau.alert.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private String title;
+
+    private String content;
+
+    public static Notification createNotification(Post post, String title, String content) {
+        Notification notification = new Notification();
+        notification.post = post;
+        notification.title = title;
+        notification.content = content;
+        return notification;
+    }
+}

--- a/src/main/java/gdsc/cau/alert/post/domain/Post.java
+++ b/src/main/java/gdsc/cau/alert/post/domain/Post.java
@@ -1,0 +1,53 @@
+package gdsc.cau.alert.post.domain;
+
+import gdsc.cau.alert.user.domain.User;
+import gdsc.cau.alert.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    private String content;
+
+    private LocalDateTime capturedAt; // 촬영일시
+
+    private String address1;
+
+    private String address2;
+
+    public static Post createPost(String imageUrl, User user, String title, String content, String address1, String address2) {
+        Post post = new Post();
+        post.imageUrl = imageUrl;
+        post.user = user;
+        post.title = title;
+        post.content = content;
+        post.address1 = address1;
+        post.address2 = address2;
+        return post;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/gdsc/cau/alert/post/domain/Vote.java
+++ b/src/main/java/gdsc/cau/alert/post/domain/Vote.java
@@ -1,0 +1,41 @@
+package gdsc.cau.alert.post.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(Vote.PK.class) // 복합키 클래스
+@Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "post_id"})
+})
+@Entity
+public class Vote {
+
+    @Id
+    @Column(name = "user_id", insertable = false, updatable = false)
+    private Long userId;
+
+    @Id
+    @Column(name = "post_id", insertable = false, updatable = false)
+    private Long postId;
+
+    private boolean isAgree;
+
+    public static Vote createVote(Long userId, Long postId, boolean isAgree) {
+        Vote vote = new Vote();
+        vote.userId = userId;
+        vote.postId = postId;
+        vote.isAgree = isAgree;
+        return vote;
+    }
+
+    public static class PK implements Serializable {
+        Long userId;
+        Long postId;
+    }
+}

--- a/src/main/java/gdsc/cau/alert/user/domain/User.java
+++ b/src/main/java/gdsc/cau/alert/user/domain/User.java
@@ -1,0 +1,42 @@
+package gdsc.cau.alert.user.domain;
+
+import gdsc.cau.alert.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "member")
+@Entity
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String name;
+
+    private String address1;
+
+    private String address2;
+
+    private int type;
+
+    public static User createUser(String name, String address1, String address2, int type) {
+        User user = new User();
+        user.name = name;
+        user.address1 = address1;
+        user.address2 = address2;
+        user.type = type;
+        return user;
+    }
+
+    public void update(String name, String address1, String address2) {
+        this.name = name;
+        this.address1 = address1;
+        this.address2 = address2;
+    }
+}

--- a/src/main/java/gdsc/cau/alert/user/domain/UserNotification.java
+++ b/src/main/java/gdsc/cau/alert/user/domain/UserNotification.java
@@ -1,0 +1,42 @@
+package gdsc.cau.alert.user.domain;
+
+import gdsc.cau.alert.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(UserNotification.PK.class) // 복합키 클래스
+@Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "notification_id"})
+})
+@Entity
+public class UserNotification extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id", insertable = false, updatable = false)
+    private Long userId;
+
+    @Id
+    @Column(name = "notification_id", insertable = false, updatable = false)
+    private Long notificationId;
+
+    private boolean isRead;
+
+    public static UserNotification createUserNotification(Long userId, Long notificationId, boolean isRead) {
+        UserNotification userNotification = new UserNotification();
+        userNotification.userId = userId;
+        userNotification.notificationId = notificationId;
+        userNotification.isRead = isRead;
+        return userNotification;
+    }
+
+    public static class PK implements Serializable {
+        Long userId;
+        Long notificationId;
+    }
+}

--- a/src/main/java/gdsc/cau/alert/util/BaseEntity.java
+++ b/src/main/java/gdsc/cau/alert/util/BaseEntity.java
@@ -1,0 +1,22 @@
+package gdsc.cau.alert.util;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}


### PR DESCRIPTION
* PostgreSQL 연동
* JPA Entity 생성 (유저, 게시물, 투표, 알림, 유저알림)
* 대부분의 객체에 타임스탬프에 존재하므로 추상클래스로부터 상속받도록 처리