### PR TITLE
[feat] firebaseAuth 기반 로그인 및 jwt 토큰 관리 구현, Docker 기반 서버 1차 배포 (#9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Docker file for building the image
+
+# jdk 17
+FROM openjdk:17
+# Copy the jar file to the container
+ARG JAR_FILE=build/libs/*.jar
+# jar file Copy
+COPY ${JAR_FILE} app.jar
+COPY serviceAccountKey.json serviceAccountKey.json
+
+ENTRYPOINT ["java","-Dspring.profiles.active=docker", "-jar","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,22 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// firebaseAuth
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jar {
+	enabled = false
 }

--- a/src/main/java/gdsc/cau/alert/auth/component/JwtAuthFilter.java
+++ b/src/main/java/gdsc/cau/alert/auth/component/JwtAuthFilter.java
@@ -1,0 +1,35 @@
+package gdsc.cau.alert.auth.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+
+        // 토큰이 유효하다면
+        if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+            // 토큰으로부터 유저 정보를 받아
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            // SecurityContext 에 객체 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/gdsc/cau/alert/auth/component/JwtTokenProvider.java
+++ b/src/main/java/gdsc/cau/alert/auth/component/JwtTokenProvider.java
@@ -1,0 +1,88 @@
+package gdsc.cau.alert.auth.component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+
+    private final UserDetailsService userDetailsService;
+
+    // 객체 초기화, secretKey를 Base64로 인코딩
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    // 토큰 생성
+    public String createAccessToken(String userPk) {
+        Claims claims = Jwts.claims().setSubject(userPk); // JWT payload 에 저장되는 정보단위
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + (60 * 60 * 1000L))) // 토큰 유효시각 설정 (1시간)
+                .signWith(key)  // 암호화 알고리즘과, secret 값
+                .compact();
+    }
+
+    public String createRefreshToken(String userPk) {
+        Claims claims = Jwts.claims().setSubject(userPk); // JWT payload 에 저장되는 정보단위
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + (7 * 24 * 60 * 60 * 1000L))) // 토큰 유효시각 설정 (1주일)
+                .signWith(key)
+                .compact();
+    }
+
+    // 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(this.getUserPk(token)));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // 토큰에서 회원 정보 추출
+    public Long getUserPk(String token) {
+        return Long.parseLong(Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject());
+    }
+
+    // 토큰 유효성, 만료일자 확인
+    public boolean validateAccessToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // Request의 Header에서 token 값 가져오기
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("accessToken");
+    }
+}

--- a/src/main/java/gdsc/cau/alert/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/cau/alert/auth/controller/AuthController.java
@@ -1,0 +1,41 @@
+package gdsc.cau.alert.auth.controller;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import gdsc.cau.alert.auth.dto.ResponseJwtDto;
+import gdsc.cau.alert.auth.service.AuthService;
+import gdsc.cau.alert.user.dto.CreateUserDto;
+import gdsc.cau.alert.util.api.ApiResponse;
+import gdsc.cau.alert.util.api.ResponseCode;
+import gdsc.cau.alert.util.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+    private final FirebaseAuth firebaseAuth;
+
+    // 로그인
+    @PostMapping("/login")
+    public ApiResponse<ResponseJwtDto> login(@RequestHeader String authToken) throws FirebaseAuthException {
+        String uid = firebaseAuth.verifyIdToken(authToken).getUid();
+        if (!authService.existsUserByUID(uid)) { // 가입되어 있지 않다면 신규 회원가입 요구
+            throw new UserException(ResponseCode.USER_NOT_FOUND);
+        }
+        return ApiResponse.success(authService.login(uid), ResponseCode.USER_LOGIN_SUCCESS.getMessage());
+    }
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ApiResponse<ResponseJwtDto> signUp(@RequestHeader String authToken, @RequestBody CreateUserDto dto) throws FirebaseAuthException {
+        String uid = firebaseAuth.verifyIdToken(authToken).getUid();
+        if (authService.existsUserByUID(uid)) { // 가입되어 있지 않다면 신규 회원가입 요구
+            throw new UserException(ResponseCode.USER_ALREADY_EXISTS);
+        }
+        return ApiResponse.success(authService.signUp(dto), ResponseCode.USER_CREATE_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/gdsc/cau/alert/auth/dto/ResponseJwtDto.java
+++ b/src/main/java/gdsc/cau/alert/auth/dto/ResponseJwtDto.java
@@ -1,0 +1,11 @@
+package gdsc.cau.alert.auth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResponseJwtDto {
+
+    private String accessToken;
+}

--- a/src/main/java/gdsc/cau/alert/auth/service/AuthService.java
+++ b/src/main/java/gdsc/cau/alert/auth/service/AuthService.java
@@ -1,0 +1,41 @@
+package gdsc.cau.alert.auth.service;
+
+import gdsc.cau.alert.auth.component.JwtTokenProvider;
+import gdsc.cau.alert.auth.dto.ResponseJwtDto;
+import gdsc.cau.alert.user.domain.User;
+import gdsc.cau.alert.user.dto.CreateUserDto;
+import gdsc.cau.alert.user.repository.UserRepository;
+import gdsc.cau.alert.util.api.ResponseCode;
+import gdsc.cau.alert.util.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 회원가입 여부 체크
+    public boolean existsUserByUID(String uid) {
+        return userRepository.existsUserByUid(uid);
+    }
+
+    // 회원가입 후 토큰 발급
+    public ResponseJwtDto signUp(CreateUserDto dto) {
+        User user = User.createUser(dto.getUserName(), dto.getUid(), dto.getAddress1(), dto.getAddress2(), dto.getType());
+        Long id = userRepository.save(user).getId();
+        return ResponseJwtDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(id.toString()))
+                .build();
+    }
+
+    // 로그인 후 토큰 발급
+    public ResponseJwtDto login(String uid) {
+        User user = userRepository.findByUid(uid).orElseThrow(() -> new UserException(ResponseCode.USER_NOT_FOUND));
+        return ResponseJwtDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(user.getId().toString()))
+                .build();
+    }
+}

--- a/src/main/java/gdsc/cau/alert/auth/service/CustomUserDetailService.java
+++ b/src/main/java/gdsc/cau/alert/auth/service/CustomUserDetailService.java
@@ -1,0 +1,24 @@
+package gdsc.cau.alert.auth.service;
+
+
+import gdsc.cau.alert.user.repository.UserRepository;
+import gdsc.cau.alert.util.api.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+
+        return userRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new UsernameNotFoundException(ResponseCode.USER_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/main/java/gdsc/cau/alert/config/FirebaseConfig.java
+++ b/src/main/java/gdsc/cau/alert/config/FirebaseConfig.java
@@ -1,0 +1,26 @@
+package gdsc.cau.alert.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseAuth firebaseAuth() throws IOException {
+        FileInputStream serviceAccount =
+                new FileInputStream("serviceAccountKey.json");
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+        FirebaseApp.initializeApp(options);
+        return FirebaseAuth.getInstance();
+    }
+}

--- a/src/main/java/gdsc/cau/alert/config/WebSecurityConfig.java
+++ b/src/main/java/gdsc/cau/alert/config/WebSecurityConfig.java
@@ -1,0 +1,40 @@
+package gdsc.cau.alert.config;
+
+import gdsc.cau.alert.auth.component.JwtAuthFilter;
+import gdsc.cau.alert.auth.component.JwtTokenProvider;
+import jakarta.servlet.DispatcherType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableMethodSecurity
+@Configuration
+public class WebSecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request -> request
+                        .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+                        .requestMatchers( "/","/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/**").permitAll()
+                        //.requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/gdsc/cau/alert/user/domain/User.java
+++ b/src/main/java/gdsc/cau/alert/user/domain/User.java
@@ -5,17 +5,23 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "member")
 @Entity
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails  {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
+
+    private String uid;
 
     private String name;
 
@@ -25,11 +31,12 @@ public class User extends BaseEntity {
 
     private String address2;
 
-    private int type;
+    private int type; // 0: 일반 사용자, 1: 관리자
 
-    public static User createUser(String name, String address1, String address2, int type) {
+    public static User createUser(String name, String uid, String address1, String address2, int type) {
         User user = new User();
         user.name = name;
+        user.uid = uid;
         user.address1 = address1;
         user.address2 = address2;
         user.type = type;
@@ -41,4 +48,41 @@ public class User extends BaseEntity {
         this.address1 = address1;
         this.address2 = address2;
     }
+
+    // Jwt 전용 설정 (UserDetails 인터페이스 구현)
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
 }

--- a/src/main/java/gdsc/cau/alert/user/dto/CreateUserDto.java
+++ b/src/main/java/gdsc/cau/alert/user/dto/CreateUserDto.java
@@ -1,0 +1,16 @@
+package gdsc.cau.alert.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateUserDto {
+
+    private String uid;
+    private String userName;
+    private String address1;
+    private String address2;
+    private String phone;
+    private int type;
+}

--- a/src/main/java/gdsc/cau/alert/user/repository/UserRepository.java
+++ b/src/main/java/gdsc/cau/alert/user/repository/UserRepository.java
@@ -3,6 +3,10 @@ package gdsc.cau.alert.user.repository;
 import gdsc.cau.alert.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsUserByUid(String uid);
+    Optional<User> findByUid(String uid);
 }

--- a/src/main/java/gdsc/cau/alert/util/api/ResponseCode.java
+++ b/src/main/java/gdsc/cau/alert/util/api/ResponseCode.java
@@ -26,6 +26,8 @@ public enum ResponseCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, false, "허용되지 않은 메소드입니다."),
 
     // 409 Conflict
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
+    ANIMAL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 동물입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다."),
@@ -40,6 +42,8 @@ public enum ResponseCode {
     ANIMAL_CREATE_SUCCESS(HttpStatus.OK, true, "동물 생성 성공"),
     ANIMAL_UPDATE_SUCCESS(HttpStatus.OK, true, "동물 수정 성공"),
     ANIMAL_DELETE_SUCCESS(HttpStatus.OK, true, "동물 삭제 성공"),
+    USER_LOGIN_SUCCESS(HttpStatus.OK, true, "사용자 로그인 성공"),
+    USER_SIGNUP_SUCCESS(HttpStatus.OK, true, "사용자 회원가입 성공"),
 
     // 201 Created
     USER_CREATE_SUCCESS(HttpStatus.CREATED, true, "사용자 생성 성공");


### PR DESCRIPTION
* JWT 관련 객체 및 WebSecurityConfig Springboot 3.2 기준으로 최신화
* 로그인/회원가입 기능 관련 계층 구현
* 가장 기본적인 유저 정보 저장 및 판별은 FirebaseAuth가 담당하며, JWT는 별도의 key로 생성
* Dockerfile 작성 및 도커 기반 서버&DB 빌드 성공, EC2 기초적인 설정 완료
* 기본적인 CI/CD 적용 예정

## Next
* 주요 기능에 대한 단위 테스트코드 작성
* 신고게시물 관련 패키지의 주요 계층 구현
* CI/CD 시스템 구축
* 실제 Postman으로 Case별 기능 검증